### PR TITLE
배포 스크립트 `docker-compose.yml` 전송 방식 개선

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,20 +27,11 @@ jobs:
             -Pdocker_id=${{ secrets.DOCKER_USERNAME }} \
             -Pdocker_pw=${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Move Docker Compose File
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.REMOTE_SERVER_HOST }}
-          username: ${{ secrets.REMOTE_SERVER_USERNAME }}
-          password: ${{ secrets.REMOTE_SERVER_PASSWORD }}
-          port: ${{ secrets.REMOTE_SERVER_PORT }}
-          source: docker-compose.yml
-          target: ~/
-
       - name: Deploy on remote server
         uses: appleboy/ssh-action@master
         env:
           IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/${{ env.CONTAINER_NAME }}:latest
+          DOCKER_COMPOSE_FILE_URL: https://raw.githubusercontent.com/takeny1998/yeohaeng-ttukttak-v3-server/refs/heads/main/docker-compose.yml
         with:
           host: ${{ secrets.REMOTE_SERVER_HOST }}
           username: ${{ secrets.REMOTE_SERVER_USERNAME }}
@@ -52,5 +43,7 @@ jobs:
             export DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}
             
             docker compose down
+            
+            curl -k ${{ env.DOCKER_COMPOSE_FILE_URL }} > docker-compose.yaml
             docker compose pull
             docker compose up -d

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-    deploy:
+    test:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout Repository
@@ -23,7 +23,7 @@ jobs:
             distribution: corretto
   
         - name: Run Test with gradlew
-          run: ./gradlew --info test
+          run: ./gradlew test
         
         - name: Publish Test Results
           uses: EnricoMi/publish-unit-test-result-action@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   database:
     image: mariadb:11.4


### PR DESCRIPTION
## 작업 목록

## 배포 스크립트 파일 전송 개선
기존에는 `SSH` 프로토콜을 사용하여 `docker-compose.yml` 파일을 전송했습니다. 이 방식은 매번 배포를 위해 `SSH` 연결을 새로 수립해야 하는 불편함이 있었습니다. 

이에 따라, **GitHub** 레포의 파일을 `curl`과 출력 리디렉션을 사용하여 간편하게 받아오는 방법으로 개선했습니다. 새로운 명령어는 다음과 같습니다:

```bash
curl -k https://raw.githubusercontent.com/{username}/{repository_name}/refs/{branch_name}/{file_path}/{file_name} > {file_name}
```

이 명령어를 통해 퍼블릭 GitHub 파일을 쉽게 다운로드할 수 있습니다.

### `docker-compose.yml` 파일 `version` 변경
Docker Compose의 `V2.5.0`부터 `version` 속성이 deprecated 되었습니다. 이에 따라, 아래와 같은 경고 메시지가 발생할 수 있습니다:

```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

혼란을 방지하기 위해, `docker-compose.yml` 파일의 상단에서 `version` 속성을 제거했습니다. 이로써 향후 버전 호환성 문제를 예방하고, 코드의 가독성을 높였습니다.


